### PR TITLE
:rocket:Storeモデル表示の際のn+1問題を解消

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -4,7 +4,7 @@ class AdminController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @stores = Store.page(params[:page]).per(25)
+    @stores = Store.page(params[:page]).per(25).includes(:mainstore)
     @mainstores = Mainstore.all
     @allstores = Store.all
     respond_to do |format|

--- a/app/controllers/api/stores_controller.rb
+++ b/app/controllers/api/stores_controller.rb
@@ -2,7 +2,8 @@
 
 class Api::StoresController < ApplicationController
   def index
-    @stores = Store.all
+    @stores = Store.all.includes(:mainstore)
+    @mainstores = Mainstore.all
   end
 
   def show

--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -2,9 +2,8 @@
 
 class StoresController < ApplicationController
   def index
-    @stores = Store.all
+    @stores = Store.all.includes(:mainstore)
     @mainstores = Mainstore.all
-    # csv_export()
   end
 
   def contact


### PR DESCRIPTION
# Storeモデル表示の際のn+1問題を解消

## 概要
- 起きていたStoresモデルのn+1問題を解消
- includes(:mainstore)で対応